### PR TITLE
Add animation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
     "paper-styles": "^2.0.0",
+    "neon-animation": "^2.2.0",
     "iron-selector": "^2.0.1",
     "paper-button": "^2.0.0",
     "iron-iconset-svg": "^2.1.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -46,7 +46,7 @@
         color: white;
       }
 
-      .demo-actions .buttons .toggle {
+      .demo-actions .buttons .toggle, .demo-actions .buttons .toggle-animation {
         background-color: var(--paper-indigo-400);
         color: white;
       }
@@ -61,11 +61,12 @@
       <div class="buttons">
         <paper-button class="reset">Reset Stepper</paper-button>
         <paper-button class="toggle">Toggle Orientation</paper-button>
+        <paper-button class="toggle-animation">Toggle Animation</paper-button>
       </div>
     </div>
     <demo-snippet>
       <template>
-        <ud-stepper linear sizing="contain">
+        <ud-stepper linear sizing="contain" animate>
           <ud-step title="Step 1">
             <div slot="content">Step 1 Content</div>
           </ud-step>
@@ -85,12 +86,13 @@
       <div class="buttons">
         <paper-button class="reset">Reset Stepper</paper-button>
         <paper-button class="toggle">Toggle Orientation</paper-button>
+        <paper-button class="toggle-animation">Toggle Animation</paper-button>
       </div>
     </div>
     <demo-snippet>
       <template>
         <ud-stepper vertical>
-          <ud-step title="Step 1">
+          <ud-step title="Step 1 animate">
             <div slot="content">Step 1 Content</div>
           </ud-step>
           <ud-step title="Step 2">
@@ -186,6 +188,12 @@
       document.querySelectorAll('paper-button.toggle').forEach(rs => {
         rs.addEventListener('tap', (evt) => {
           evt.target.parentElement.parentElement.parentElement.querySelector('ud-stepper').toggleOrientation();
+        });
+      });
+
+      document.querySelectorAll('paper-button.toggle-animation').forEach(rs => {
+        rs.addEventListener('tap', (evt) => {
+          evt.target.parentElement.parentElement.parentElement.querySelector('ud-stepper').toggleAnimation();
         });
       });
     });

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,7 +23,10 @@
           color: rgba(0, 0, 0, 0.8);
         }
       }
-
+    
+      ud-stepper  {
+        min-height: 350px;
+      }
       .demo-actions {
         display: flex;
         flex-direction: row;
@@ -62,7 +65,7 @@
     </div>
     <demo-snippet>
       <template>
-        <ud-stepper linear>
+        <ud-stepper linear sizing="contain">
           <ud-step title="Step 1">
             <div slot="content">Step 1 Content</div>
           </ud-step>
@@ -110,7 +113,7 @@
     </div>
     <demo-snippet>
       <template>
-        <ud-stepper linear>
+        <ud-stepper linear sizing="contain">
           <ud-step title="Step 1" editable>
             <div slot="content">Step 1 Content</div>
           </ud-step>

--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -170,7 +170,7 @@
     }
 
     :host([vertical][animate]) .step-container {
-      height: 10px;
+      height: 0px;
     }
 
     :host([vertical][animate]) [selected] .step-container {
@@ -513,6 +513,13 @@
          */
         toggleOrientation() {
           this.vertical = !this.vertical;
+        }
+
+        /**
+         * Toggle the animation 
+         */
+        toggleAnimation() {
+          this.animate = !this.animate;
         }
 
         _handleStepActivate(evt) {

--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -120,6 +120,10 @@
       background-color: var(--ud-stepper-icon-seleced-color, var(--google-blue-500));
     }
 
+    :host(:not([animate])) ::slotted(ud-step:not([selected])) {
+      display: none;
+    }
+
     /* Vertical Styles */
 
     :host([vertical]) .header-container {
@@ -178,13 +182,9 @@
       height: fit-content;
     }
 
-     :host(:not([animate])) ::slotted(ud-step:not([selected])) {
-        display: none;
-      }
-
     :host(:not([animate])) .vertical-step ::slotted(ud-step:not([selected])) {
-        display: none;
-      }
+      display: none;
+    }
 
 
     vertical-step ::slotted(ud-step:not([selected])) {
@@ -231,9 +231,9 @@
     </iron-selector>
     <dom-if if="[[!vertical]]" restamp>
       <template>
-         <dom-if if="[[animate]]" restamp>
+        <dom-if if="[[animate]]" restamp>
           <template>
-            <neon-animated-pages selected="[[selected]]" entry-animation="slide-from-right-animation" exit-animation="slide-left-animation">
+            <neon-animated-pages id="pageContainer" selected="[[selected]]" entry-animation="slide-from-right-animation" exit-animation="slide-left-animation">
               <slot name="horizontal"></slot>
             </neon-animated-pages>
           </template>
@@ -337,9 +337,9 @@
           /* 
            * `_maxHeight` the height of larger step.
            */
-           _maxHeight : {
-             type:  Number,
-             },
+          _maxHeight: {
+            type: Number,
+          },
         };
       }
 
@@ -347,7 +347,7 @@
         return [
           '_setSlotNames(_steps,vertical)',
           '_setHeight(sizing, _maxHeight, vertical, animate)'
-          ]
+        ];
       }
 
       constructor() {
@@ -360,7 +360,7 @@
             Polymer.RenderStatus.afterNextRender(this, () => {
               this._setHeight(this.sizing, this._maxHeight, this.vertical, this.animate);
             });
-            
+
             if (!this.selected) {
               this.selected = 0;
             }
@@ -372,14 +372,9 @@
         super.ready();
         this.addEventListener('step-action', evt => this._handleStepAction(evt));
         this.addEventListener('step-error', evt => {
-          this.notifyPath('_steps')
+          this.notifyPath('_steps');
         });
       }
-
-      // connectedCallback() {
-      //   super.connectedCallback();
-      //   // Note(cg): we need to reset sizing here as $.selector was not properly sized on intial call.
-      // }
 
       _findSteps() {
         return Array.from(this.querySelectorAll('ud-step'));
@@ -388,186 +383,189 @@
       _prepareSteps(steps) {
         let maxHeight = 0;
         steps.forEach((step, i) => {
-            //don't overwrite the step's actions, if they're already set
-            if (step.actions) return;
+          //don't overwrite the step's actions, if they're already set
+          if (step.actions) return;
 
-            //By default all steps have continue and cancel action
-            const actions = [{
-              name: 'continue'
-            }, {
-              name: 'cancel'
-            }];
-            if (!this.linear) {
-              //Disable the back for the first step
-              actions.push({
-                name: 'back',
-                disabled: i === 0
-              });
-            } else if (step.optional) {
-              //In linear stepper, optional step has a skip action
-              actions.push({
-                name: 'skip'
-              });
-            }
-            step.actions = actions;
-
-            const stepHeight = parseInt(getComputedStyle(step).height);
-              if (stepHeight > maxHeight) {
-                maxHeight = stepHeight;
-              }
+          //By default all steps have continue and cancel action
+          const actions = [{
+            name: 'continue'
+          }, {
+            name: 'cancel'
+          }];
+          if (!this.linear) {
+            //Disable the back for the first step
+            actions.push({
+              name: 'back',
+              disabled: i === 0
             });
-          this._maxHeight = maxHeight;
-        }
-
-        /* 
-         * `_setHeight` set height of stepper if sizing === 'contain'. 
-         * This is now necessary as `ud-steps` are absoluted positionned within neon-animated-page. Hence, stepper cannot be aware of its own size.
-         */
-        _setHeight(sizing, maxHeight, vertical, animate) {
-          // Note(cg): this is only useful for horizontal and animated layout (relying on neon-animated-page).
-          if(vertical === true || animate !== true) {
-            this.style.height = null;
-            return;
+          } else if (step.optional) {
+            //In linear stepper, optional step has a skip action
+            actions.push({
+              name: 'skip'
+            });
           }
+          step.actions = actions;
 
-          if (sizing === 'contain' && maxHeight ) {
-            this.style.height = this.$.selector.getBoundingClientRect().height + maxHeight + 3 + 'px';
+          const stepHeight = parseInt(getComputedStyle(step).height);
+          if (stepHeight > maxHeight) {
+            maxHeight = stepHeight;
           }
+        });
+        this._maxHeight = maxHeight;
+      }
+
+      /* 
+       * `_setHeight` set height of stepper if sizing === 'contain'. 
+       * This is now necessary as `ud-steps` are absoluted positionned within neon-animated-page. Hence, stepper cannot be aware of its own size.
+       */
+      _setHeight(sizing, maxHeight, vertical, animate) {
+        // Note(cg): this is only useful for horizontal and animated layout (relying on neon-animated-page).
+        const pageContainer = this.shadowRoot.querySelector('#pageContainer');
+        if(!pageContainer) {return;}
+        if (vertical === true || animate !== true) {
+          pageContainer.style.height = null;
+          return;
         }
 
-        _isStep(node) {
-          return node.nodeType === Node.ELEMENT_NODE && /ud-step/i.test(node.localName);
-        }
-
-        _getStepNumber(index) {
-          return index + 1;
-        }
-
-        _handleStepAction(evt) {
-          const actionHandler = this[evt.detail.toLowerCase()];
-          if (actionHandler) actionHandler.apply(this, [evt.target]);
-        }
-
-        _findNextStep(currentStep) {
-          if (currentStep == this._steps.length - 1) return currentStep;
-          //if it's a linear stepper, find the next not completed or editable step
-          if (this.linear) {
-            let index = currentStep + 1;
-            while (index < this._steps.length - 1) {
-              let step = this._steps[index];
-              if (step.editable || !step.completed) {
-                return index;
-              }
-              index++;
-            }
-            return index;
-          } else {
-            return currentStep + 1;
-          }
-        }
-
-        /**
-         * Go to the next available step
-         */
-        next() {
-          if (!this._steps) return;
-          this.continue(this._steps[this.selected]);
-        }
-
-        /** @protected */
-        continue (step) {
-          if (this.linear && step.error) return;
-          step.completed = true;
-          this.notifyPath('_steps');
-          this.selected = this._findNextStep(this.selected);
-        }
-
-        /** @protected */
-        back(step) {
-          if (this.selected > 0) {
-            this.selected = this.selected - 1;
-          }
-        }
-
-        /** @protected */
-        skip(step) {
-          this.selected = this._findNextStep(this.selected);
-        }
-
-        /** @protected */
-        cancel(step) {
-
-        }
-
-        /**
-         * Reset the stepper and all its steps to the initial state.
-         */
-        reset() {
-          this.selected = 0;
-          this._steps.forEach(s => s._reset());
-          this.notifyPath('_steps');
-        }
-
-        /**
-         * Toggle the orientation between horizontal and vertical
-         */
-        toggleOrientation() {
-          this.vertical = !this.vertical;
-        }
-
-        /**
-         * Toggle the animation 
-         */
-        toggleAnimation() {
-          this.animate = !this.animate;
-        }
-
-        _handleStepActivate(evt) {
-          /*
-           * the logic here:
-           * User is allowed to select any step if stepper is not linear
-           * If stepper is linear: 
-           *  - allow user to revisit a completed editable step
-           *  - allow user to revist an optional step as long as is not completed
-           */
-          if (this.linear) {
-            const step = this._steps[evt.detail.selected];
-            if (!step) return;
-            if ((step.completed && step.editable) || (!step.completed && step.optional)) {
-              return;
-            }
-            evt.preventDefault();
-          }
-        }
-
-        _setSlotNames(steps, vertical) {
-          if (!this._steps) return;
-          steps.forEach((step, i) => {
-            step.setAttribute('slot', this.vertical ? 'slot' + i : 'horizontal');
-          });
-        }
-
-        _selectionChanged(selected) {
-
-          this._steps.forEach((step, i) => {
-            step.selected = i == selected;
-          });
-        }
-
-        _isCompleted(steps) {
-          if (!steps || steps.length === 0) return false;
-          //stepper is completed when all non-optional steps are completed.
-          return steps.filter(s => s.completed || s.optional).length == steps.length;
+        if (sizing === 'contain' && maxHeight) {
+          pageContainer.style.height = maxHeight + 3 + 'px';
+          // this.style.height = this.$.selector.getBoundingClientRect().height + maxHeight + 3 + 'px';
         }
       }
 
-      window.customElements.define(UdStepperElement.is, UdStepperElement);
+      _isStep(node) {
+        return node.nodeType === Node.ELEMENT_NODE && /ud-step/i.test(node.localName);
+      }
+
+      _getStepNumber(index) {
+        return index + 1;
+      }
+
+      _handleStepAction(evt) {
+        const actionHandler = this[evt.detail.toLowerCase()];
+        if (actionHandler) actionHandler.apply(this, [evt.target]);
+      }
+
+      _findNextStep(currentStep) {
+        if (currentStep == this._steps.length - 1) return currentStep;
+        //if it's a linear stepper, find the next not completed or editable step
+        if (this.linear) {
+          let index = currentStep + 1;
+          while (index < this._steps.length - 1) {
+            let step = this._steps[index];
+            if (step.editable || !step.completed) {
+              return index;
+            }
+            index++;
+          }
+          return index;
+        } else {
+          return currentStep + 1;
+        }
+      }
 
       /**
-       * @namespace UrDeveloper
+       * Go to the next available step
        */
-      window.UrDeveloper = window.UrDeveloper || {};
-      UrDeveloper.UdStepperElement = UdStepperElement;
+      next() {
+        if (!this._steps) return;
+        this.continue(this._steps[this.selected]);
+      }
+
+      /** @protected */
+      continue (step) {
+        if (this.linear && step.error) return;
+        step.completed = true;
+        this.notifyPath('_steps');
+        this.selected = this._findNextStep(this.selected);
+      }
+
+      /** @protected */
+      back(step) {
+        if (this.selected > 0) {
+          this.selected = this.selected - 1;
+        }
+      }
+
+      /** @protected */
+      skip(step) {
+        this.selected = this._findNextStep(this.selected);
+      }
+
+      /** @protected */
+      cancel(step) {
+
+      }
+
+      /**
+       * Reset the stepper and all its steps to the initial state.
+       */
+      reset() {
+        this.selected = 0;
+        this._steps.forEach(s => s._reset());
+        this.notifyPath('_steps');
+      }
+
+      /**
+       * Toggle the orientation between horizontal and vertical
+       */
+      toggleOrientation() {
+        this.vertical = !this.vertical;
+      }
+
+      /**
+       * Toggle the animation 
+       */
+      toggleAnimation() {
+        this.animate = !this.animate;
+      }
+
+      _handleStepActivate(evt) {
+        /*
+         * the logic here:
+         * User is allowed to select any step if stepper is not linear
+         * If stepper is linear: 
+         *  - allow user to revisit a completed editable step
+         *  - allow user to revist an optional step as long as is not completed
+         */
+        if (this.linear) {
+          const step = this._steps[evt.detail.selected];
+          if (!step) return;
+          if ((step.completed && step.editable) || (!step.completed && step.optional)) {
+            return;
+          }
+          evt.preventDefault();
+        }
+      }
+
+      _setSlotNames(steps, vertical) {
+        if (!this._steps) return;
+        steps.forEach((step, i) => {
+          step.setAttribute('slot', this.vertical ? 'slot' + i : 'horizontal');
+        });
+      }
+
+      _selectionChanged(selected) {
+
+        this._steps.forEach((step, i) => {
+          step.selected = i == selected;
+        });
+      }
+
+      _isCompleted(steps) {
+        if (!steps || steps.length === 0) return false;
+        //stepper is completed when all non-optional steps are completed.
+        return steps.filter(s => s.completed || s.optional).length == steps.length;
+      }
     }
+
+    window.customElements.define(UdStepperElement.is, UdStepperElement);
+
+    /**
+     * @namespace UrDeveloper
+     */
+    window.UrDeveloper = window.UrDeveloper || {};
+    UrDeveloper.UdStepperElement = UdStepperElement;
+  }
   </script>
 </dom-module>

--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -160,23 +160,31 @@
       padding: 24px 24px 16px 24px;
     }
 
-    .vertical-step ::slotted(ud-step) {
+    :host([animate]) .vertical-step ::slotted(ud-step) {
       transform: scaleY(0);
       transition: transform 0.26s ease;
     }
 
-    .vertical-step ::slotted(ud-step[selected]) {
+    :host([animate]) .vertical-step ::slotted(ud-step[selected]) {
       transform: scaleY(1);
     }
 
-    :host([vertical]) .step-container {
+    :host([vertical][animate]) .step-container {
       height: 10px;
     }
 
-    :host([vertical]) [selected] .step-container {
+    :host([vertical][animate]) [selected] .step-container {
       display: flex;
       height: fit-content;
     }
+
+     :host(:not([animate])) ::slotted(ud-step:not([selected])) {
+        display: none;
+      }
+
+    :host(:not([animate])) .vertical-step ::slotted(ud-step:not([selected])) {
+        display: none;
+      }
 
 
     vertical-step ::slotted(ud-step:not([selected])) {
@@ -223,9 +231,18 @@
     </iron-selector>
     <dom-if if="[[!vertical]]" restamp>
       <template>
-        <neon-animated-pages selected="[[selected]]" entry-animation="slide-from-right-animation" exit-animation="slide-left-animation">
-          <slot name="horizontal"></slot>
-        </neon-animated-pages>
+         <dom-if if="[[animate]]" restamp>
+          <template>
+            <neon-animated-pages selected="[[selected]]" entry-animation="slide-from-right-animation" exit-animation="slide-left-animation">
+              <slot name="horizontal"></slot>
+            </neon-animated-pages>
+          </template>
+        </dom-if>
+        <dom-if if="[[!animate]]" restamp>
+          <template>
+            <slot name="horizontal"></slot>
+          </template>
+        </dom-if>
       </template>
     </dom-if>
   </template>
@@ -263,6 +280,15 @@
            * If true, the stepper becomes vertical.
            */
           vertical: {
+            type: Boolean,
+            value: false,
+            reflectToAttribute: Boolean
+          },
+
+          /**
+           * If true, the stepper performs animations.
+           */
+          animate: {
             type: Boolean,
             value: false,
             reflectToAttribute: Boolean
@@ -320,7 +346,7 @@
       static get observers() {
         return [
           '_setSlotNames(_steps,vertical)',
-          '_setHeight(sizing, _maxHeight, vertical)'
+          '_setHeight(sizing, _maxHeight, vertical, animate)'
           ]
       }
 
@@ -332,7 +358,7 @@
             this._steps = this._findSteps();
             this._prepareSteps(this._steps);
             Polymer.RenderStatus.afterNextRender(this, () => {
-              this._setHeight(this.sizing, this._maxHeight, this.vertical);
+              this._setHeight(this.sizing, this._maxHeight, this.vertical, this.animate);
             });
             
             if (!this.selected) {
@@ -397,8 +423,9 @@
          * `_setHeight` set height of stepper if sizing === 'contain'. 
          * This is now necessary as `ud-steps` are absoluted positionned within neon-animated-page. Hence, stepper cannot be aware of its own size.
          */
-        _setHeight(sizing, maxHeight, vertical) {
-          if(vertical === true) {
+        _setHeight(sizing, maxHeight, vertical, animate) {
+          // Note(cg): this is only useful for horizontal and animated layout (relying on neon-animated-page).
+          if(vertical === true || animate !== true) {
             this.style.height = null;
             return;
           }

--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -1,172 +1,189 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../neon-animation/web-animations.html">
+<link rel="import" href="../neon-animation/neon-animated-pages.html">
+<link rel="import" href="../neon-animation/neon-animations.html">
 <link rel="import" href="../paper-styles/element-styles/paper-material-styles.html">
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../iron-selector/iron-selector.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../polymer/lib/mixins/mutable-data.html">
-
 <link rel="import" href="ud-step.html">
 <link rel="import" href="ud-iconset.html">
-
+<!-- <link rel="import" href="ud-stepper-animate-style.html"> -->
 <dom-module id="ud-stepper">
   <template>
     <style include="paper-material-styles">
-      :host {
-        display: flex;
-        flex-direction: column;
-      }
+    :host {
+      display: flex;
+      flex-direction: column;
+      overflow-x: hidden;
+    }
 
-      .header-container {
-        display: flex;
-        flex-direction: row;
+    .header-container {
+      display: flex;
+      flex-direction: row;
 
-        flex-wrap: nowrap;
-        align-items: center;
-        @apply --ud-stepper-header-container-style;
-      }
+      flex-wrap: nowrap;
+      align-items: center;
+      @apply --ud-stepper-header-container-style;
+    }
 
-      /* Horizontal Styles */
+    /* Horizontal Styles */
 
-      .header {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        overflow: hidden;
-      }
+    .header {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      overflow: hidden;
+    }
 
-      :host(:not([vertical])) .header:not(:last-of-type) {
-        flex: 1;
-      }
+    :host(:not([vertical])) .header:not(:last-of-type) {
+      flex: 1;
+    }
 
-      :host(:not([vertical])) .header:not(:last-of-type)::after {
-        content: '';
-        display: inline-block;
-        position: relative;
-        flex: 1;
-        top: 36px;
-        height: 1px;
-        margin-left: -12px;
-        width: 200px;
-        background-color: rgba(0, 0, 0, 0.1);
-      }
+    :host(:not([vertical])) .header:not(:last-of-type)::after {
+      content: '';
+      display: inline-block;
+      position: relative;
+      flex: 1;
+      top: 36px;
+      height: 1px;
+      margin-left: -12px;
+      width: 200px;
+      background-color: rgba(0, 0, 0, 0.1);
+    }
 
-      .header .label {
-        display: flex;
-        flex-direction: row;
-        cursor: pointer;
-        align-items: center;
-        padding: 24px 24px 24px 24px;
-      }
+    .header .label {
+      display: flex;
+      flex-direction: row;
+      cursor: pointer;
+      align-items: center;
+      padding: 24px 24px 24px 24px;
+    }
 
-      .header .label:hover {
-        background-color: #f0f0f0;
-      }
+    .header .label:hover {
+      background-color: #f0f0f0;
+    }
 
-      .label-icon {
-        color: rgba(0, 0, 0, 0.38);
-        @apply --paper-font-caption;
-        text-align: center;
-        line-height: 24px;
-      }
+    .label-icon {
+      color: rgba(0, 0, 0, 0.38);
+      @apply --paper-font-caption;
+      text-align: center;
+      line-height: 24px;
+    }
 
-      .label-text {
-        @apply --paper-font-body2;
-        padding-left: 8px;
-        color: rgba(0, 0, 0, 0.54);
-      }
+    .label-text {
+      @apply --paper-font-body2;
+      padding-left: 8px;
+      color: rgba(0, 0, 0, 0.54);
+    }
 
-      .label-text .optional,
-      .label-text .summary {
-        @apply --paper-font-caption;
-      }
+    .label-text .optional,
+    .label-text .summary {
+      @apply --paper-font-caption;
+    }
 
-      :host(:not([vertical])) .label-text .main {
-        @apply --paper-font-common-nowrap;
-        max-width: 120px;
-      }
+    :host(:not([vertical])) .label-text .main {
+      @apply --paper-font-common-nowrap;
+      max-width: 120px;
+    }
 
-      .header.selected .label-icon,
-      .header[completed] .label-icon {
-        color: var(--ud-stepper-icon-completed-color, var(--google-blue-500));
-      }
+    .header.selected .label-icon,
+    .header[completed] .label-icon {
+      color: var(--ud-stepper-icon-completed-color, var(--google-blue-500));
+    }
 
-      .header.selected .label-text,
-      .header[completed] .label-text {
-        color: rgba(0, 0, 0, 0.87);
-      }
+    .header.selected .label-text,
+    .header[completed] .label-text {
+      color: rgba(0, 0, 0, 0.87);
+    }
 
-      .header[error] .label-text,
-      .header[error] .label-icon {
-        color: var(--ud-stepper-icon-error-color, --paper-deep-orange-a700);
-      }
+    .header[error] .label-text,
+    .header[error] .label-icon {
+      color: var(--ud-stepper-icon-error-color, --paper-deep-orange-a700);
+    }
 
-      .step-number {
-        color: white;
-        background-color: rgba(0, 0, 0, 0.38);
-        border-radius: 50%;
-        line-height: 24px;
-        width: 24px;
-        height: 24px;
-        max-height: 24px;
-        max-width: 24px;
-      }
+    .step-number {
+      color: white;
+      background-color: rgba(0, 0, 0, 0.38);
+      border-radius: 50%;
+      line-height: 24px;
+      width: 24px;
+      height: 24px;
+      max-height: 24px;
+      max-width: 24px;
+    }
 
-      .header.selected .step-number {
-        background-color: var(--ud-stepper-icon-seleced-color, var(--google-blue-500));
-      }
+    .header.selected .step-number {
+      background-color: var(--ud-stepper-icon-seleced-color, var(--google-blue-500));
+    }
 
-      /* Vertical Styles */
+    /* Vertical Styles */
 
-      :host([vertical]) .header-container {
-        flex-direction: column;
-        flex-wrap: nowrap;
-        align-items: stretch;
-      }
+    :host([vertical]) .header-container {
+      flex-direction: column;
+      flex-wrap: nowrap;
+      align-items: stretch;
+    }
 
-      :host([vertical]) .header {
-        flex-direction: column;
-        justify-content: flex-start;
-        overflow: visible;
-      }
+    :host([vertical]) .header {
+      flex-direction: column;
+      justify-content: flex-start;
+      overflow: visible;
+    }
 
-      :host([vertical]) .vertical-step ::slotted(ud-step) {
-        flex: 1;
-      }
+    :host([vertical]) .vertical-step ::slotted(ud-step) {
+      flex: 1;
+    }
 
-      .vertical-step {
-        padding-left: 32px;
-        display: flex;
-        flex-flow: row;
-        align-items: stretch;
-      }
+    .vertical-step {
+      padding-left: 32px;
+      display: flex;
+      flex-flow: row;
+      align-items: stretch;
+    }
 
-      .header:not(:last-of-type) .vertical-step::before {
-        content: '';
-        display: inline-block;
-        position: relative;
-        width: 1px;
-        left: 3px;
-        margin-top: -10px;
-        margin-bottom: -16px;
-        background-color: rgba(0, 0, 0, 0.1);
-      }
+    .header:not(:last-of-type) .vertical-step::before {
+      content: '';
+      display: inline-block;
+      position: relative;
+      width: 1px;
+      left: 3px;
+      margin-top: -10px;
+      margin-bottom: -16px;
+      background-color: rgba(0, 0, 0, 0.1);
+    }
 
-      :host([vertical]) .header .label {
-        padding: 24px 24px 16px 24px;
-      }
+    :host([vertical]) .header .label {
+      padding: 24px 24px 16px 24px;
+    }
 
-      ::slotted(ud-step:not([selected])) {
-        display: none;
-      }
+    .vertical-step ::slotted(ud-step) {
+      transform: scaleY(0);
+      transition: transform 0.26s ease;
+    }
 
-      .vertical-step ::slotted(ud-step:not([selected])) {
-        display: none;
-      }
+    .vertical-step ::slotted(ud-step[selected]) {
+      transform: scaleY(1);
+    }
+
+    :host([vertical]) .step-container {
+      height: 10px;
+    }
+
+    :host([vertical]) [selected] .step-container {
+      display: flex;
+      height: fit-content;
+    }
+
+
+    vertical-step ::slotted(ud-step:not([selected])) {
+      display: none;
+    }
     </style>
-    <iron-selector id="selector" class="header-container" selectable=".header.selectable" selected-class="selected" selected="{{selected}}"
-      on-iron-activate="_handleStepActivate" selected-attribute="selected">
+    <iron-selector id="selector" class="header-container" selectable=".header.selectable" selected-class="selected" selected="{{selected}}" on-iron-activate="_handleStepActivate" selected-attribute="selected">
       <dom-repeat items="[[_steps]]" mutable-data>
         <template>
           <div class="header selectable" completed$="[[item.completed]]" error$="[[item.error]]">
@@ -201,122 +218,150 @@
               </template>
             </dom-if>
           </div>
-          </div>
         </template>
       </dom-repeat>
     </iron-selector>
     <dom-if if="[[!vertical]]" restamp>
       <template>
-        <slot name="horizontal"></slot>
-        </div>
+        <neon-animated-pages selected="[[selected]]" entry-animation="slide-from-right-animation" exit-animation="slide-left-animation">
+          <slot name="horizontal"></slot>
+        </neon-animated-pages>
       </template>
     </dom-if>
   </template>
-
   <script>
-    {
-      /**
-       * `ud-stepper`
-       * Material Design Stepper
-       *
-       * ### Styling
-       *
-       * The following custom properties and mixins are available for styling:
-       *
-       * Custom Property | Description | Default
-       * ----------------------|-------------|--------
-       * `--ud-stepper-header-container-style` | Style mixin for the header container | `{}`
-       * `--ud-stepper-icon-completed-color` | The icon color of a completed step | `--google-blue-500`
-       * `--ud-stepper-icon-error-color` | The icon color of a step with error | `--paper-deep-orange-a700`
-       * `--ud-stepper-icon-seleced-color` | The icon color of a selected step | `--google-blue-500`
-       *
-       * @customElement
-       * @polymer
-       * @memberof UrDeveloper
-       * @demo demo/index.html
-       */
-      class UdStepperElement extends Polymer.MutableData(Polymer.Element) {
-        static get is() {
-          return 'ud-stepper';
-        }
+  {
+    /**
+     * `ud-stepper`
+     * Material Design Stepper
+     *
+     * ### Styling
+     *
+     * The following custom properties and mixins are available for styling:
+     *
+     * Custom Property | Description | Default
+     * ----------------------|-------------|--------
+     * `--ud-stepper-header-container-style` | Style mixin for the header container | `{}`
+     * `--ud-stepper-icon-completed-color` | The icon color of a completed step | `--google-blue-500`
+     * `--ud-stepper-icon-error-color` | The icon color of a step with error | `--paper-deep-orange-a700`
+     * `--ud-stepper-icon-seleced-color` | The icon color of a selected step | `--google-blue-500`
+     *
+     * @customElement
+     * @polymer
+     * @memberof UrDeveloper
+     * @demo demo/index.html
+     */
+    class UdStepperElement extends Polymer.MutableData(Polymer.Element) {
+      static get is() {
+        return 'ud-stepper';
+      }
 
-        static get properties() {
-          return {
+      static get properties() {
+        return {
 
-            /**
-             * If true, the stepper becomes vertical.
-             */
-            vertical: {
-              type: Boolean,
-              value: false,
-              reflectToAttribute: Boolean
-            },
+          /**
+           * If true, the stepper becomes vertical.
+           */
+          vertical: {
+            type: Boolean,
+            value: false,
+            reflectToAttribute: Boolean
+          },
 
-            /**
-             * If true, the stepper becomes linear.
-             */
-            linear: {
-              type: Boolean,
-              reflectToAttribute: Boolean
-            },
+          /**
+           * If true, the stepper becomes linear.
+           */
+          linear: {
+            type: Boolean,
+            reflectToAttribute: Boolean
+          },
 
-            _steps: {
-              type: Array
-            },
+          _steps: {
+            type: Array
+          },
 
-            /**
-            * Gets or sets the currently selected step index (zero based).
-            **/
-            selected: {
-              type: String,
-              notify: true,
-              observer: '_selectionChanged'
-            },
+          /**
+           * Gets or sets the currently selected step index (zero based).
+           **/
+          selected: {
+            type: String,
+            notify: true,
+            observer: '_selectionChanged'
+          },
 
-            /**
-            * Determines if the stepper is compeleted. The stepper is completed when all its non-optional steps are completed.
-            **/
-            completed: {
-              type: Boolean,
-              notify: true,
-              reflectToAttribute: true,
-              computed: '_isCompleted(_steps)'
+          /**
+           * Determines if the stepper is compeleted. The stepper is completed when all its non-optional steps are completed.
+           **/
+          completed: {
+            type: Boolean,
+            notify: true,
+            reflectToAttribute: true,
+            computed: '_isCompleted(_steps)'
+          },
+
+          /* 
+           * `sizing` string | null | undefined = null
+           * Sets a sizing option for the stepper. 
+           * Valid values is `contain` (will set the height of the stepper so as to contain the larger ud-step).
+           */
+          sizing: {
+            type: String
+          },
+
+          /* 
+           * `_maxHeight` the height of larger step.
+           */
+           _maxHeight : {
+             type:  Number,
+             },
+        };
+      }
+
+      static get observers() {
+        return [
+          '_setSlotNames(_steps,vertical)',
+          '_setHeight(sizing, _maxHeight, vertical)'
+          ]
+      }
+
+      constructor() {
+        super();
+        this._templateObserver = new Polymer.FlattenedNodesObserver(this, info => {
+          if (info.addedNodes.filter(this._isStep).length > 0 ||
+            info.removedNodes.filter(this._isStep).length > 0) {
+            this._steps = this._findSteps();
+            this._prepareSteps(this._steps);
+            Polymer.RenderStatus.afterNextRender(this, () => {
+              this._setHeight(this.sizing, this._maxHeight, this.vertical);
+            });
+            
+            if (!this.selected) {
+              this.selected = 0;
             }
-          };
-        }
+          }
+        });
+      }
 
-        static get observers() {
-          return ['_setSlotNames(_steps,vertical)']
-        }
+      ready() {
+        super.ready();
+        this.addEventListener('step-action', evt => this._handleStepAction(evt));
+        this.addEventListener('step-error', evt => {
+          this.notifyPath('_steps')
+        });
+      }
 
-        constructor() {
-          super();
-          this._templateObserver = new Polymer.FlattenedNodesObserver(this, info => {
-            if (info.addedNodes.filter(this._isStep).length > 0 ||
-              info.removedNodes.filter(this._isStep).length > 0) {
-              this._steps = this._findSteps();
-              this._prepareSteps(this._steps);
-              if (!this.selected) {
-                this.selected = 0;
-              }
-            }
-          });
-        }
+      // connectedCallback() {
+      //   super.connectedCallback();
+      //   // Note(cg): we need to reset sizing here as $.selector was not properly sized on intial call.
+      // }
 
-        ready() {
-          super.ready();
-          this.addEventListener('step-action', evt => this._handleStepAction(evt));
-          this.addEventListener('step-error', evt => {
-            this.notifyPath('_steps')
-          });
-        }
+      _findSteps() {
+        return Array.from(this.querySelectorAll('ud-step'));
+      }
 
-        _findSteps() {
-          return Array.from(this.querySelectorAll('ud-step'));
-        }
-
-        _prepareSteps(steps) {
-          steps.forEach((step, i) => {
+      _prepareSteps(steps) {
+        let maxHeight = 0;
+        steps.forEach((step, i) => {
             //don't overwrite the step's actions, if they're already set
             if (step.actions) return;
 
@@ -331,7 +376,7 @@
               actions.push({
                 name: 'back',
                 disabled: i === 0
-              })
+              });
             } else if (step.optional) {
               //In linear stepper, optional step has a skip action
               actions.push({
@@ -339,7 +384,28 @@
               });
             }
             step.actions = actions;
-          });
+
+            const stepHeight = parseInt(getComputedStyle(step).height);
+              if (stepHeight > maxHeight) {
+                maxHeight = stepHeight;
+              }
+            });
+          this._maxHeight = maxHeight;
+        }
+
+        /* 
+         * `_setHeight` set height of stepper if sizing === 'contain'. 
+         * This is now necessary as `ud-steps` are absoluted positionned within neon-animated-page. Hence, stepper cannot be aware of its own size.
+         */
+        _setHeight(sizing, maxHeight, vertical) {
+          if(vertical === true) {
+            this.style.height = null;
+            return;
+          }
+
+          if (sizing === 'contain' && maxHeight ) {
+            this.style.height = this.$.selector.getBoundingClientRect().height + maxHeight + 3 + 'px';
+          }
         }
 
         _isStep(node) {
@@ -374,15 +440,15 @@
         }
 
         /**
-        * Go to the next available step
-        */
+         * Go to the next available step
+         */
         next() {
           if (!this._steps) return;
           this.continue(this._steps[this.selected]);
         }
 
         /** @protected */
-        continue(step) {
+        continue (step) {
           if (this.linear && step.error) return;
           step.completed = true;
           this.notifyPath('_steps');


### PR DESCRIPTION
I am aware that neon-animation is deprecated in Polymer 2.0, but it is still the easier way to add animations...

- added a new `animate` property. When true, stepper transitions are animated (vertical and horizontal)
- added a `sizing` property. When `sizing === "contain"` and `animate` is true, stepper will adjust its height to the larger step (necessary as neon-animated uses absolute positioning, unaware of its own size). 

Sorry for the 4 vs 2 space tab - don't know how to revert that back or instruct diff to ignore it.