### PR TITLE
allow custom implementation of step-action

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -214,7 +214,7 @@
           window.addEventListener('WebComponentsReady', function() {
             app = document.querySelector('#app')
             app.next = e =>{
-               e.target.dispatchEvent(new CustomEvent('step-action', {detail: 'continue', bubbles: true, composed: true})); 
+               e.target.dispatchEvent(new CustomEvent('step-action', {detail: 'next', bubbles: true, composed: true})); 
             }; 
             app.back = e =>{
                e.target.dispatchEvent(new CustomEvent('step-action', {detail: 'back', bubbles: true, composed: true})); 

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,49 +4,47 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-
   <title>ud-stepper demo</title>
-
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../paper-button/paper-button.html">
   <link rel="import" href="../ud-stepper.html">
-
   <custom-style>
     <style is="custom-style" include="demo-pages-shared-styles">
-      ud-step {
-        height: 250px;
-        --ud-step-content-style: {
-          background-color: rgba(0, 0, 0, .1);
-          padding: 5px;
-          color: rgba(0, 0, 0, 0.8);
-        }
-      }
+    ud-step {
+      height: 250px;
 
-      .demo-actions {
-        display: flex;
-        flex-direction: row;
-        padding: 10px 0px 10px 0px;
-        align-items: center;
-        justify-content: space-between;
+      --ud-step-content-style: {
+        background-color: rgba(0, 0, 0, .1);
+        padding: 5px;
+        color: rgba(0, 0, 0, 0.8);
       }
+    }
 
-      .demo-actions .buttons {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-end;
-      }
+    .demo-actions {
+      display: flex;
+      flex-direction: row;
+      padding: 10px 0px 10px 0px;
+      align-items: center;
+      justify-content: space-between;
+    }
 
-      .demo-actions .buttons .reset {
-        background-color: var(--paper-pink-400);
-        color: white;
-      }
+    .demo-actions .buttons {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+    }
 
-      .demo-actions .buttons .toggle {
-        background-color: var(--paper-indigo-400);
-        color: white;
-      }
+    .demo-actions .buttons .reset {
+      background-color: var(--paper-pink-400);
+      color: white;
+    }
+
+    .demo-actions .buttons .toggle {
+      background-color: var(--paper-indigo-400);
+      color: white;
+    }
     </style>
   </custom-style>
 </head>
@@ -172,20 +170,75 @@
       </template>
     </demo-snippet>
   </div>
-  <script>
-    window.addEventListener('WebComponentsReady', function () {
-      document.querySelectorAll('paper-button.reset').forEach(rs => {
-        rs.addEventListener('tap', (evt) => {
-          evt.target.parentElement.parentElement.parentElement.querySelector('ud-stepper').reset();
-        });
-      });
+  <div class="vertical-section-container centered">
+    <div class="demo-actions">
+      <h3>Custom action implementation </h3>
+      <div class="buttons">
+        <paper-button class="reset">Reset Stepper</paper-button>
+        <paper-button class="toggle">Toggle Orientation</paper-button>
+      </div>
+    </div>
+    <demo-snippet>
+      <template>
+        <dom-bind id="app">
+          <template>
+            <style>
+            paper-button {
+              background: white;
+            }
 
-      document.querySelectorAll('paper-button.toggle').forEach(rs => {
-        rs.addEventListener('tap', (evt) => {
-          evt.target.parentElement.parentElement.parentElement.querySelector('ud-stepper').toggleOrientation();
-        });
+            ;
+            </style>
+            <ud-stepper linear>
+              <ud-step title="Step 1" hide-actions editable>
+                <div slot="content">
+                  <div>Step 1 Content, custom action</div>
+                  <paper-button raised on-tap="next"  >next</paper-button>
+                </div>
+              </ud-step>
+              <ud-step title="Step 2">
+                <div slot="content">
+                  <div>Step 2 Content, custom action</div>
+                  <div>
+                    <paper-button raised on-tap="back">back</paper-button>
+                    <paper-button raised on-tap="next">next</paper-button>
+                  </div>
+                </div>
+              </ud-step>
+              <ud-step title="Step 3">
+                <div slot="content">Step 3 Content</div>
+              </ud-step>
+            </ud-stepper>
+          </template>
+          <script>
+          window.addEventListener('WebComponentsReady', function() {
+            app = document.querySelector('#app')
+            app.next = e =>{
+               e.target.dispatchEvent(new CustomEvent('step-action', {detail: 'continue', bubbles: true, composed: true})); 
+            }; 
+            app.back = e =>{
+               e.target.dispatchEvent(new CustomEvent('step-action', {detail: 'back', bubbles: true, composed: true})); 
+            }; 
+          });
+          </script>
+        </dom-bind>
+      </template>
+    </demo-snippet>
+  </div>
+  <script>
+  window.addEventListener('WebComponentsReady', function() {
+    document.querySelectorAll('paper-button.reset').forEach(rs => {
+      rs.addEventListener('tap', (evt) => {
+        evt.target.parentElement.parentElement.parentElement.querySelector('ud-stepper').reset();
       });
     });
+
+    document.querySelectorAll('paper-button.toggle').forEach(rs => {
+      rs.addEventListener('tap', (evt) => {
+        evt.target.parentElement.parentElement.parentElement.querySelector('ud-stepper').toggleOrientation();
+      });
+    });
+  });
   </script>
 </body>
 

--- a/ud-step.html
+++ b/ud-step.html
@@ -240,9 +240,6 @@
 
       ready() {
         super.ready();
-        Polymer.RenderStatus.afterNextRender(this, () => {
-          this.addEventListener('step-action', this._onContentStepAction);
-        });
       }
 
       connectedCallback() {
@@ -264,13 +261,6 @@
               ab.addEventListener('click', (evt) => this._handleAction(evt));
             });
           });
-        }
-      }
-
-      _onContentStepAction(e) {
-        if (e.target !== this) {
-          e.stopPropagation();
-          this._handleAction(e, e.detail);
         }
       }
 

--- a/ud-step.html
+++ b/ud-step.html
@@ -2,60 +2,59 @@
 <link rel="import" href="../paper-button/paper-button.html">
 <link rel="import" href="../paper-styles/element-styles/paper-material-styles.html">
 <link rel="import" href="../paper-styles/typography.html">
-
 <dom-module id="ud-step">
   <template>
     <style include="paper-material-styles">
-      :host {
-        display: flex;
-        flex-direction: column;
-      }
+    :host {
+      display: flex;
+      flex-direction: column;
+    }
 
-      #content {
-        flex: 1;
-        @apply --ud-step-content-style;
-        margin: 24px 24px 16px 24px;
-      }
+    #content {
+      flex: 1;
+      @apply --ud-step-content-style;
+      margin: 24px 24px 16px 24px;
+    }
 
-      #actions {
-        padding: 0px 24px 8px 24px;
-        display: flex;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        justify-content: space-between;
-        align-items: center;
-        height: 48px;
-      }
+    #actions {
+      padding: 0px 24px 8px 24px;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+      align-items: center;
+      height: 48px;
+    }
 
-      :host[hide-actions] #actions {
-        display: none;
-      }
+    :host([hide-actions]) #actions {
+      display: none;
+    }
 
-      #actions ::slotted(.linear-actions),
-      .linear-actions {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-end;
-        align-items: center;
-        flex: 1;
-      }
+    #actions ::slotted(.linear-actions),
+    .linear-actions {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+      align-items: center;
+      flex: 1;
+    }
 
-      paper-button,
-      #actions ::slotted(paper-button) {
-        @apply --paper-font-button;
-        color: rgba(0, 0, 0, 0.83);
-      }
+    paper-button,
+    #actions ::slotted(paper-button) {
+      @apply --paper-font-button;
+      color: rgba(0, 0, 0, 0.83);
+    }
 
-      .continue-btn,
-      #actions ::slotted(.continue-btn) {
-        color: var(--ud-step-continue-btn-color, var(--google-blue-500));
-      }
+    .continue-btn,
+    #actions ::slotted(.continue-btn) {
+      color: var(--ud-step-continue-btn-color, var(--google-blue-500));
+    }
 
-      paper-button[disabled],
-      #actions ::slotted(paper-button[disabled]) {
-        color: rgba(0, 0, 0, 0.50);
-        background-color: transparent;
-      }
+    paper-button[disabled],
+    #actions ::slotted(paper-button[disabled]) {
+      color: rgba(0, 0, 0, 0.50);
+      background-color: transparent;
+    }
     </style>
     <div id="content">
       <slot name="content"></slot>
@@ -74,251 +73,261 @@
     </div>
   </template>
   <script>
-    {
-      /**
-       * `ud-step`
-       * Material Design Step
-       *
-       * ### Styling
-       *
-       * The following custom properties and mixins are available for styling:
-       *
-       * Custom Property | Description | Default
-       * ----------------------|-------------|--------
-       * `--ud-step-content-style` | Style mixin of the step content | `{}`
-       * `--ud-step-continue-btn-color` | Continue button color | `--google-blue-500`
-       *
-       * @customElement
-       * @polymer
-       * @memberof UrDeveloper
-       */
-      class UdStepElement extends (class extends Polymer.Element {}) {
-        static get is() {
-          return 'ud-step';
-        }
+  {
+    /**
+     * `ud-step`
+     * Material Design Step
+     *
+     * ### Styling
+     *
+     * The following custom properties and mixins are available for styling:
+     *
+     * Custom Property | Description | Default
+     * ----------------------|-------------|--------
+     * `--ud-step-content-style` | Style mixin of the step content | `{}`
+     * `--ud-step-continue-btn-color` | Continue button color | `--google-blue-500`
+     *
+     * @customElement
+     * @polymer
+     * @memberof UrDeveloper
+     */
+    class UdStepElement extends(class extends Polymer.Element {}) {
+      static get is() {
+        return 'ud-step';
+      }
 
-        static get properties() {
-          return {
-            /**
-             * Step title
-             */
-            title: {
-              type: String,
-              reflectToAttribute: true
-            },
-            /**
-             * Step summary that apears under the title
-             */
-            summary: {
-              type: String,
-              reflectToAttribute: true
-            },
-            /**
-             * Makes the step editable which in linear stepper user can go back to it.
-             */
-            editable: {
-              type: Boolean
-            },
-            /**
-             * Makes the step optional which allows user to skip it.
-             */
-            optional: {
-              type: Boolean
-            },
+      static get properties() {
+        return {
+          /**
+           * Step title
+           */
+          title: {
+            type: String,
+            reflectToAttribute: true
+          },
+          /**
+           * Step summary that apears under the title
+           */
+          summary: {
+            type: String,
+            reflectToAttribute: true
+          },
+          /**
+           * Makes the step editable which in linear stepper user can go back to it.
+           */
+          editable: {
+            type: Boolean
+          },
+          /**
+           * Makes the step optional which allows user to skip it.
+           */
+          optional: {
+            type: Boolean
+          },
 
-            /**
-             * Determines if this is the current step in stepper.
-             */
-            selected: {
-              type: Boolean,
-              readonly: true,
-              reflectToAttribute: true,
-              notify: true
-            },
+          /**
+           * Determines if this is the current step in stepper.
+           */
+          selected: {
+            type: Boolean,
+            readonly: true,
+            reflectToAttribute: true,
+            notify: true
+          },
 
-            /**
-             * Determines if the step is completed.
-             */
-            completed: {
-              type: Boolean,
-              readonly: true,
-              notify: true
-            },
+          /**
+           * Determines if the step is completed.
+           */
+          completed: {
+            type: Boolean,
+            readonly: true,
+            notify: true
+          },
 
-            /**
-            * The `actions` property can be used to override the default behavior of the step's actions.
-            * You can define what actions are available, their texts and whether are enabled or disabled.
-            * for example: 
-            * ```json
-            *  {
-            *    {
-            *      name: 'continue', title: 'Next'
-            *    },
-            *    {
-            *      name: 'cancel', title: 'Reset', disabled: true
-            *    }
-            *  }
-            * ```
-            */
-            actions: {
-              type: Array
-            },
+          /**
+           * The `actions` property can be used to override the default behavior of the step's actions.
+           * You can define what actions are available, their texts and whether are enabled or disabled.
+           * for example: 
+           * ```json
+           *  {
+           *    {
+           *      name: 'continue', title: 'Next'
+           *    },
+           *    {
+           *      name: 'cancel', title: 'Reset', disabled: true
+           *    }
+           *  }
+           * ```
+           */
+          actions: {
+            type: Array
+          },
 
-            /**
-             * Step icon when it's not completed yet. 
-             * If not specified, a step number will be shown instead.
-             */
-            icon: {
-              type: String
-            },
+          /**
+           * Step icon when it's not completed yet. 
+           * If not specified, a step number will be shown instead.
+           */
+          icon: {
+            type: String
+          },
 
-            /**
-             * Step icon when it's completed.
-             */
-            completedIcon: {
-              type: String,
-              value: 'ud:check-circle'
-            },
+          /**
+           * Step icon when it's completed.
+           */
+          completedIcon: {
+            type: String,
+            value: 'ud:check-circle'
+          },
 
-            /**
-             * Step icon when it's editable.
-             */
-            editableIcon: {
-              type: String,
-              value: 'ud:edit-circle'
-            },
+          /**
+           * Step icon when it's editable.
+           */
+          editableIcon: {
+            type: String,
+            value: 'ud:edit-circle'
+          },
 
-            /**
-             * The icon that will be shown when the step is in invalid state.
-             */
-            errorIcon: {
-              type: String,
-              value: 'ud:warning'
-            },
+          /**
+           * The icon that will be shown when the step is in invalid state.
+           */
+          errorIcon: {
+            type: String,
+            value: 'ud:warning'
+          },
 
-            /**
-            * Text for an optional step.
-            */
-            optionalText: {
-              type: String,
-              value: 'Optional'
-            },
+          /**
+           * Text for an optional step.
+           */
+          optionalText: {
+            type: String,
+            value: 'Optional'
+          },
 
-            /**
-            * Indicates if the step is in error state. 
-            * In a linear stepper, user cannot continue with an error state.
-            */
-            error: {
-              type: Boolean,
-              observer: '_errorChanged',
-              reflectToAttribute: true
-            },
+          /**
+           * Indicates if the step is in error state. 
+           * In a linear stepper, user cannot continue with an error state.
+           */
+          error: {
+            type: Boolean,
+            observer: '_errorChanged',
+            reflectToAttribute: true
+          },
 
-            /**
-            * Hide the actions bar
-            */
-            hideActions: {
-              type: Boolean,
-              reflectToAttribute: true,
-              value: false
-            },
+          /**
+           * Hide the actions bar
+           */
+          hideActions: {
+            type: Boolean,
+            reflectToAttribute: true,
+            value: false
+          },
 
-            _currentIcon: {
-              type: String,
-              computed: '_computeCurrentIcon(completed, editable, error)',
-              notify: true
-            },
+          _currentIcon: {
+            type: String,
+            computed: '_computeCurrentIcon(completed, editable, error)',
+            notify: true
+          },
 
-            _actionButtons: {
-              type: Array
-            }
+          _actionButtons: {
+            type: Array
           }
-        }
+        };
+      }
 
-        static get observers() {
-          return ['_updateActionsButtons(_actionButtons.*,_linearActionButtons.*,actions.*)']
-        }
+      static get observers() {
+        return ['_updateActionsButtons(_actionButtons.*,_linearActionButtons.*,actions.*)'];
+      }
 
-        ready() {
-          super.ready();
-        }
+      ready() {
+        super.ready();
+        Polymer.RenderStatus.afterNextRender(this, () => {
+          this.addEventListener('step-action', this._onContentStepAction);
+        });
+      }
 
-        connectedCallback() {
-          super.connectedCallback();
-          if (this.hideActions) return;
-          if (this.$.actionsSlot) {
-            this._nodeObserver = new Polymer.FlattenedNodesObserver(this.$.actionsSlot, (info) => {
-              this._actionButtons = Array.from(info.addedNodes.filter(n=>n.nodeType === Node.ELEMENT_NODE && n.hasAttribute("data-action")));
-              this._actionButtons.filter(ab => !ab._hooked).forEach(ab => {
-                ab.addEventListener('click', (evt) => this._handleAction(evt));
-              });
+      connectedCallback() {
+        super.connectedCallback();
+        if (this.hideActions) return;
+        if (this.$.actionsSlot) {
+          this._nodeObserver = new Polymer.FlattenedNodesObserver(this.$.actionsSlot, (info) => {
+            this._actionButtons = Array.from(info.addedNodes.filter(n => n.nodeType === Node.ELEMENT_NODE && n.hasAttribute('data-action')));
+            this._actionButtons.filter(ab => !ab._hooked).forEach(ab => {
+              ab.addEventListener('click', (evt) => this._handleAction(evt));
             });
-          }
-
-          if (this.$.linearActionsSlot) {
-            this._nodeObserver1 = new Polymer.FlattenedNodesObserver(this.$.linearActionsSlot, (info) => {
-              this._linearActionButtons = Array.from(info.addedNodes.filter(n=>n.nodeType === Node.ELEMENT_NODE && n.hasAttribute("data-action")));
-              this._linearActionButtons.filter(ab => !ab._hooked).forEach(ab => {
-                ab.addEventListener('click', (evt) => this._handleAction(evt));
-              });
-            });
-          }
-        }
-
-        _updateActionsButtons(actionButtons, linearActionButtons, allowedActions) {
-          if (!allowedActions.base) return;
-          let actionBtns = (actionButtons.base || []).concat(linearActionButtons.base || []);
-          actionBtns.forEach(ab => {
-            const actionName = ab.getAttribute('data-action');
-            const action = this.actions.find(a => a.name === actionName);
-            if (!action) {
-              ab.style.display = 'none';
-            } else {
-              ab.disabled = action.disabled;
-              if (action.title) {
-                ab.innerText = action.title;
-              }
-            }
           });
         }
 
-        _handleAction(evt) {
-          this.dispatchEvent(new CustomEvent('step-action', {
-            detail: evt.target.getAttribute('data-action'),
-            bubbles: true
-          }));
-        }
-
-        _computeCurrentIcon(completed, editable, error) {
-          if (error) return this.errorIcon;
-
-          if (completed) {
-            return editable ? this.editableIcon : this.completedIcon;
-          }
-          return this.icon;
-        }
-
-        _errorChanged(invalid) {
-          this.dispatchEvent(new CustomEvent('step-error', {
-            detail: {
-              stpe: this
-            },
-            bubbles: true
-          }));
-        }
-
-        _reset() {
-          this.completed = false;
+        if (this.$.linearActionsSlot) {
+          this._nodeObserver1 = new Polymer.FlattenedNodesObserver(this.$.linearActionsSlot, (info) => {
+            this._linearActionButtons = Array.from(info.addedNodes.filter(n => n.nodeType === Node.ELEMENT_NODE && n.hasAttribute('data-action')));
+            this._linearActionButtons.filter(ab => !ab._hooked).forEach(ab => {
+              ab.addEventListener('click', (evt) => this._handleAction(evt));
+            });
+          });
         }
       }
 
-      window.customElements.define(UdStepElement.is, UdStepElement);
+      _onContentStepAction(e) {
+        if (e.target !== this) {
+          e.stopPropagation();
+          this._handleAction(e, e.detail);
+        }
+      }
 
-      /**
-       * @namespace UrDeveloper
-       */
-      window.UrDeveloper = window.UrDeveloper || {};
-      UrDeveloper.UdStepElement = UdStepElement;
+      _updateActionsButtons(actionButtons, linearActionButtons, allowedActions) {
+        if (!allowedActions.base) return;
+        let actionBtns = (actionButtons.base || []).concat(linearActionButtons.base || []);
+        actionBtns.forEach(ab => {
+          const actionName = ab.getAttribute('data-action');
+          const action = this.actions.find(a => a.name === actionName);
+          if (!action) {
+            ab.style.display = 'none';
+          } else {
+            ab.disabled = action.disabled;
+            if (action.title) {
+              ab.innerText = action.title;
+            }
+          }
+        });
+      }
+
+      _handleAction(evt, action) {
+        this.dispatchEvent(new CustomEvent('step-action', {
+          detail: action || evt.target.getAttribute('data-action'),
+          bubbles: true
+        }));
+      }
+
+      _computeCurrentIcon(completed, editable, error) {
+        if (error) return this.errorIcon;
+
+        if (completed) {
+          return editable ? this.editableIcon : this.completedIcon;
+        }
+        return this.icon;
+      }
+
+      _errorChanged(invalid) {
+        this.dispatchEvent(new CustomEvent('step-error', {
+          detail: {
+            stpe: this
+          },
+          bubbles: true
+        }));
+      }
+
+      _reset() {
+        this.completed = false;
+      }
     }
+
+    window.customElements.define(UdStepElement.is, UdStepElement);
+
+    /**
+     * @namespace UrDeveloper
+     */
+    window.UrDeveloper = window.UrDeveloper || {};
+    UrDeveloper.UdStepElement = UdStepElement;
+  }
   </script>
 </dom-module>

--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -6,167 +6,164 @@
 <link rel="import" href="../iron-selector/iron-selector.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../polymer/lib/mixins/mutable-data.html">
-
 <link rel="import" href="ud-step.html">
 <link rel="import" href="ud-iconset.html">
-
 <dom-module id="ud-stepper">
   <template>
     <style include="paper-material-styles">
-      :host {
-        display: flex;
-        flex-direction: column;
-      }
+    :host {
+      display: flex;
+      flex-direction: column;
+    }
 
-      .header-container {
-        display: flex;
-        flex-direction: row;
+    .header-container {
+      display: flex;
+      flex-direction: row;
 
-        flex-wrap: nowrap;
-        align-items: center;
-        @apply --ud-stepper-header-container-style;
-      }
+      flex-wrap: nowrap;
+      align-items: center;
+      @apply --ud-stepper-header-container-style;
+    }
 
-      /* Horizontal Styles */
+    /* Horizontal Styles */
 
-      .header {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        overflow: hidden;
-      }
+    .header {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      overflow: hidden;
+    }
 
-      :host(:not([vertical])) .header:not(:last-of-type) {
-        flex: 1;
-      }
+    :host(:not([vertical])) .header:not(:last-of-type) {
+      flex: 1;
+    }
 
-      :host(:not([vertical])) .header:not(:last-of-type)::after {
-        content: '';
-        display: inline-block;
-        position: relative;
-        flex: 1;
-        top: 36px;
-        height: 1px;
-        margin-left: -12px;
-        width: 200px;
-        background-color: rgba(0, 0, 0, 0.1);
-      }
+    :host(:not([vertical])) .header:not(:last-of-type)::after {
+      content: '';
+      display: inline-block;
+      position: relative;
+      flex: 1;
+      top: 36px;
+      height: 1px;
+      margin-left: -12px;
+      width: 200px;
+      background-color: rgba(0, 0, 0, 0.1);
+    }
 
-      .header .label {
-        display: flex;
-        flex-direction: row;
-        cursor: pointer;
-        align-items: center;
-        padding: 24px 24px 24px 24px;
-      }
+    .header .label {
+      display: flex;
+      flex-direction: row;
+      cursor: pointer;
+      align-items: center;
+      padding: 24px 24px 24px 24px;
+    }
 
-      .header .label:hover {
-        background-color: #f0f0f0;
-      }
+    .header .label:hover {
+      background-color: #f0f0f0;
+    }
 
-      .label-icon {
-        color: rgba(0, 0, 0, 0.38);
-        @apply --paper-font-caption;
-        text-align: center;
-        line-height: 24px;
-      }
+    .label-icon {
+      color: rgba(0, 0, 0, 0.38);
+      @apply --paper-font-caption;
+      text-align: center;
+      line-height: 24px;
+    }
 
-      .label-text {
-        @apply --paper-font-body2;
-        padding-left: 8px;
-        color: rgba(0, 0, 0, 0.54);
-      }
+    .label-text {
+      @apply --paper-font-body2;
+      padding-left: 8px;
+      color: rgba(0, 0, 0, 0.54);
+    }
 
-      .label-text .optional,
-      .label-text .summary {
-        @apply --paper-font-caption;
-      }
+    .label-text .optional,
+    .label-text .summary {
+      @apply --paper-font-caption;
+    }
 
-      :host(:not([vertical])) .label-text .main {
-        @apply --paper-font-common-nowrap;
-        max-width: 120px;
-      }
+    :host(:not([vertical])) .label-text .main {
+      @apply --paper-font-common-nowrap;
+      max-width: 120px;
+    }
 
-      .header.selected .label-icon,
-      .header[completed] .label-icon {
-        color: var(--ud-stepper-icon-completed-color, var(--google-blue-500));
-      }
+    .header.selected .label-icon,
+    .header[completed] .label-icon {
+      color: var(--ud-stepper-icon-completed-color, var(--google-blue-500));
+    }
 
-      .header.selected .label-text,
-      .header[completed] .label-text {
-        color: rgba(0, 0, 0, 0.87);
-      }
+    .header.selected .label-text,
+    .header[completed] .label-text {
+      color: rgba(0, 0, 0, 0.87);
+    }
 
-      .header[error] .label-text,
-      .header[error] .label-icon {
-        color: var(--ud-stepper-icon-error-color, --paper-deep-orange-a700);
-      }
+    .header[error] .label-text,
+    .header[error] .label-icon {
+      color: var(--ud-stepper-icon-error-color, --paper-deep-orange-a700);
+    }
 
-      .step-number {
-        color: white;
-        background-color: rgba(0, 0, 0, 0.38);
-        border-radius: 50%;
-        line-height: 24px;
-        width: 24px;
-        height: 24px;
-        max-height: 24px;
-        max-width: 24px;
-      }
+    .step-number {
+      color: white;
+      background-color: rgba(0, 0, 0, 0.38);
+      border-radius: 50%;
+      line-height: 24px;
+      width: 24px;
+      height: 24px;
+      max-height: 24px;
+      max-width: 24px;
+    }
 
-      .header.selected .step-number {
-        background-color: var(--ud-stepper-icon-seleced-color, var(--google-blue-500));
-      }
+    .header.selected .step-number {
+      background-color: var(--ud-stepper-icon-seleced-color, var(--google-blue-500));
+    }
 
-      /* Vertical Styles */
+    /* Vertical Styles */
 
-      :host([vertical]) .header-container {
-        flex-direction: column;
-        flex-wrap: nowrap;
-        align-items: stretch;
-      }
+    :host([vertical]) .header-container {
+      flex-direction: column;
+      flex-wrap: nowrap;
+      align-items: stretch;
+    }
 
-      :host([vertical]) .header {
-        flex-direction: column;
-        justify-content: flex-start;
-        overflow: visible;
-      }
+    :host([vertical]) .header {
+      flex-direction: column;
+      justify-content: flex-start;
+      overflow: visible;
+    }
 
-      :host([vertical]) .vertical-step ::slotted(ud-step) {
-        flex: 1;
-      }
+    :host([vertical]) .vertical-step ::slotted(ud-step) {
+      flex: 1;
+    }
 
-      .vertical-step {
-        padding-left: 32px;
-        display: flex;
-        flex-flow: row;
-        align-items: stretch;
-      }
+    .vertical-step {
+      padding-left: 32px;
+      display: flex;
+      flex-flow: row;
+      align-items: stretch;
+    }
 
-      .header:not(:last-of-type) .vertical-step::before {
-        content: '';
-        display: inline-block;
-        position: relative;
-        width: 1px;
-        left: 3px;
-        margin-top: -10px;
-        margin-bottom: -16px;
-        background-color: rgba(0, 0, 0, 0.1);
-      }
+    .header:not(:last-of-type) .vertical-step::before {
+      content: '';
+      display: inline-block;
+      position: relative;
+      width: 1px;
+      left: 3px;
+      margin-top: -10px;
+      margin-bottom: -16px;
+      background-color: rgba(0, 0, 0, 0.1);
+    }
 
-      :host([vertical]) .header .label {
-        padding: 24px 24px 16px 24px;
-      }
+    :host([vertical]) .header .label {
+      padding: 24px 24px 16px 24px;
+    }
 
-      ::slotted(ud-step:not([selected])) {
-        display: none;
-      }
+    ::slotted(ud-step:not([selected])) {
+      display: none;
+    }
 
-      .vertical-step ::slotted(ud-step:not([selected])) {
-        display: none;
-      }
+    .vertical-step ::slotted(ud-step:not([selected])) {
+      display: none;
+    }
     </style>
-    <iron-selector id="selector" class="header-container" selectable=".header.selectable" selected-class="selected" selected="{{selected}}"
-      on-iron-activate="_handleStepActivate" selected-attribute="selected">
+    <iron-selector id="selector" class="header-container" selectable=".header.selectable" selected-class="selected" selected="{{selected}}" on-iron-activate="_handleStepActivate" selected-attribute="selected">
       <dom-repeat items="[[_steps]]" mutable-data>
         <template>
           <div class="header selectable" completed$="[[item.completed]]" error$="[[item.error]]">
@@ -212,262 +209,262 @@
       </template>
     </dom-if>
   </template>
-
   <script>
-    {
-      /**
-       * `ud-stepper`
-       * Material Design Stepper
-       *
-       * ### Styling
-       *
-       * The following custom properties and mixins are available for styling:
-       *
-       * Custom Property | Description | Default
-       * ----------------------|-------------|--------
-       * `--ud-stepper-header-container-style` | Style mixin for the header container | `{}`
-       * `--ud-stepper-icon-completed-color` | The icon color of a completed step | `--google-blue-500`
-       * `--ud-stepper-icon-error-color` | The icon color of a step with error | `--paper-deep-orange-a700`
-       * `--ud-stepper-icon-seleced-color` | The icon color of a selected step | `--google-blue-500`
-       *
-       * @customElement
-       * @polymer
-       * @memberof UrDeveloper
-       * @demo demo/index.html
-       */
-      class UdStepperElement extends Polymer.MutableData(Polymer.Element) {
-        static get is() {
-          return 'ud-stepper';
-        }
+  {
+    /**
+     * `ud-stepper`
+     * Material Design Stepper
+     *
+     * ### Styling
+     *
+     * The following custom properties and mixins are available for styling:
+     *
+     * Custom Property | Description | Default
+     * ----------------------|-------------|--------
+     * `--ud-stepper-header-container-style` | Style mixin for the header container | `{}`
+     * `--ud-stepper-icon-completed-color` | The icon color of a completed step | `--google-blue-500`
+     * `--ud-stepper-icon-error-color` | The icon color of a step with error | `--paper-deep-orange-a700`
+     * `--ud-stepper-icon-seleced-color` | The icon color of a selected step | `--google-blue-500`
+     *
+     * @customElement
+     * @polymer
+     * @memberof UrDeveloper
+     * @demo demo/index.html
+     */
+    class UdStepperElement extends Polymer.MutableData(Polymer.Element) {
+      static get is() {
+        return 'ud-stepper';
+      }
 
-        static get properties() {
-          return {
+      static get properties() {
+        return {
 
-            /**
-             * If true, the stepper becomes vertical.
-             */
-            vertical: {
-              type: Boolean,
-              value: false,
-              reflectToAttribute: Boolean
-            },
-
-            /**
-             * If true, the stepper becomes linear.
-             */
-            linear: {
-              type: Boolean,
-              reflectToAttribute: Boolean
-            },
-
-            _steps: {
-              type: Array
-            },
-
-            /**
-            * Gets or sets the currently selected step index (zero based).
-            **/
-            selected: {
-              type: String,
-              notify: true,
-              observer: '_selectionChanged'
-            },
-
-            /**
-            * Determines if the stepper is compeleted. The stepper is completed when all its non-optional steps are completed.
-            **/
-            completed: {
-              type: Boolean,
-              notify: true,
-              reflectToAttribute: true,
-              computed: '_isCompleted(_steps)'
-            }
-          };
-        }
-
-        static get observers() {
-          return ['_setSlotNames(_steps,vertical)']
-        }
-
-        constructor() {
-          super();
-          this._templateObserver = new Polymer.FlattenedNodesObserver(this, info => {
-            if (info.addedNodes.filter(this._isStep).length > 0 ||
-              info.removedNodes.filter(this._isStep).length > 0) {
-              this._steps = this._findSteps();
-              this._prepareSteps(this._steps);
-              if (!this.selected) {
-                this.selected = 0;
-              }
-            }
-          });
-        }
-
-        ready() {
-          super.ready();
-          this.addEventListener('step-action', evt => this._handleStepAction(evt));
-          this.addEventListener('step-error', evt => {
-            this.notifyPath('_steps')
-          });
-        }
-
-        _findSteps() {
-          return Array.from(this.querySelectorAll('ud-step'));
-        }
-
-        _prepareSteps(steps) {
-          steps.forEach((step, i) => {
-            //don't overwrite the step's actions, if they're already set
-            if (step.actions) return;
-
-            //By default all steps have continue and cancel action
-            const actions = [{
-              name: 'continue'
-            }, {
-              name: 'cancel'
-            }];
-            if (!this.linear) {
-              //Disable the back for the first step
-              actions.push({
-                name: 'back',
-                disabled: i === 0
-              })
-            } else if (step.optional) {
-              //In linear stepper, optional step has a skip action
-              actions.push({
-                name: 'skip'
-              });
-            }
-            step.actions = actions;
-          });
-        }
-
-        _isStep(node) {
-          return node.nodeType === Node.ELEMENT_NODE && /ud-step/i.test(node.localName);
-        }
-
-        _getStepNumber(index) {
-          return index + 1;
-        }
-
-        _handleStepAction(evt) {
-          const actionHandler = this[evt.detail.toLowerCase()];
-          if (actionHandler) actionHandler.apply(this, [evt.target]);
-        }
-
-        _findNextStep(currentStep) {
-          if (currentStep == this._steps.length - 1) return currentStep;
-          //if it's a linear stepper, find the next not completed or editable step
-          if (this.linear) {
-            let index = currentStep + 1;
-            while (index < this._steps.length - 1) {
-              let step = this._steps[index];
-              if (step.editable || !step.completed) {
-                return index;
-              }
-              index++;
-            }
-            return index;
-          } else {
-            return currentStep + 1;
-          }
-        }
-
-        /**
-        * Go to the next available step
-        */
-        next() {
-          if (!this._steps) return;
-          this.continue(this._steps[this.selected]);
-        }
-
-        /** @protected */
-        continue(step) {
-          if (this.linear && step.error) return;
-          step.completed = true;
-          this.notifyPath('_steps');
-          this.selected = this._findNextStep(this.selected);
-        }
-
-        /** @protected */
-        back(step) {
-          if (this.selected > 0) {
-            this.selected = this.selected - 1;
-          }
-        }
-
-        /** @protected */
-        skip(step) {
-          this.selected = this._findNextStep(this.selected);
-        }
-
-        /** @protected */
-        cancel(step) {
-
-        }
-
-        /**
-         * Reset the stepper and all its steps to the initial state.
-         */
-        reset() {
-          this.selected = 0;
-          this._steps.forEach(s => s._reset());
-          this.notifyPath('_steps');
-        }
-
-        /**
-         * Toggle the orientation between horizontal and vertical
-         */
-        toggleOrientation() {
-          this.vertical = !this.vertical;
-        }
-
-        _handleStepActivate(evt) {
-          /*
-           * the logic here:
-           * User is allowed to select any step if stepper is not linear
-           * If stepper is linear: 
-           *  - allow user to revisit a completed editable step
-           *  - allow user to revist an optional step as long as is not completed
+          /**
+           * If true, the stepper becomes vertical.
            */
-          if (this.linear) {
-            const step = this._steps[evt.detail.selected];
-            if (!step) return;
-            if ((step.completed && step.editable) || (!step.completed && step.optional)) {
-              return;
-            }
-            evt.preventDefault();
+          vertical: {
+            type: Boolean,
+            value: false,
+            reflectToAttribute: Boolean
+          },
+
+          /**
+           * If true, the stepper becomes linear.
+           */
+          linear: {
+            type: Boolean,
+            reflectToAttribute: Boolean
+          },
+
+          _steps: {
+            type: Array
+          },
+
+          /**
+           * Gets or sets the currently selected step index (zero based).
+           **/
+          selected: {
+            type: String,
+            notify: true,
+            observer: '_selectionChanged'
+          },
+
+          /**
+           * Determines if the stepper is compeleted. The stepper is completed when all its non-optional steps are completed.
+           **/
+          completed: {
+            type: Boolean,
+            notify: true,
+            reflectToAttribute: true,
+            computed: '_isCompleted(_steps)'
           }
-        }
+        };
+      }
 
-        _setSlotNames(steps, vertical) {
-          if (!this._steps) return;
-          steps.forEach((step, i) => {
-            step.setAttribute('slot', this.vertical ? 'slot' + i : 'horizontal');
-          });
-        }
+      static get observers() {
+        return ['_setSlotNames(_steps,vertical)']
+      }
 
-        _selectionChanged(selected) {
+      constructor() {
+        super();
+        this._templateObserver = new Polymer.FlattenedNodesObserver(this, info => {
+          if (info.addedNodes.filter(this._isStep).length > 0 ||
+            info.removedNodes.filter(this._isStep).length > 0) {
+            this._steps = this._findSteps();
+            this._prepareSteps(this._steps);
+            if (!this.selected) {
+              this.selected = 0;
+            }
+          }
+        });
+      }
 
-          this._steps.forEach((step, i) => {
-            step.selected = i == selected;
-          });
-        }
+      ready() {
+        super.ready();
+        this.addEventListener('step-action', evt => this._handleStepAction(evt));
+        this.addEventListener('step-error', evt => {
+          this.notifyPath('_steps')
+        });
+      }
 
-        _isCompleted(steps) {
-          if (!steps || steps.length === 0) return false;
-          //stepper is completed when all non-optional steps are completed.
-          return steps.filter(s => s.completed || s.optional).length == steps.length;
+      _findSteps() {
+        return Array.from(this.querySelectorAll('ud-step'));
+      }
+
+      _prepareSteps(steps) {
+        steps.forEach((step, i) => {
+          //don't overwrite the step's actions, if they're already set
+          if (step.actions) return;
+
+          //By default all steps have continue and cancel action
+          const actions = [{
+            name: 'continue'
+          }, {
+            name: 'cancel'
+          }];
+          if (!this.linear) {
+            //Disable the back for the first step
+            actions.push({
+              name: 'back',
+              disabled: i === 0
+            })
+          } else if (step.optional) {
+            //In linear stepper, optional step has a skip action
+            actions.push({
+              name: 'skip'
+            });
+          }
+          step.actions = actions;
+        });
+      }
+
+      _isStep(node) {
+        return node.nodeType === Node.ELEMENT_NODE && /ud-step/i.test(node.localName);
+      }
+
+      _getStepNumber(index) {
+        return index + 1;
+      }
+
+      _handleStepAction(evt) {
+        const actionHandler = this[evt.detail.toLowerCase()];
+        const step = evt.path.find(node => this._isStep(node));
+        if (actionHandler && step) actionHandler.apply(this, [step]);
+      }
+
+      _findNextStep(currentStep) {
+        if (currentStep == this._steps.length - 1) return currentStep;
+        //if it's a linear stepper, find the next not completed or editable step
+        if (this.linear) {
+          let index = currentStep + 1;
+          while (index < this._steps.length - 1) {
+            let step = this._steps[index];
+            if (step.editable || !step.completed) {
+              return index;
+            }
+            index++;
+          }
+          return index;
+        } else {
+          return currentStep + 1;
         }
       }
 
-      window.customElements.define(UdStepperElement.is, UdStepperElement);
+      /**
+       * Go to the next available step
+       */
+      next() {
+        if (!this._steps) return;
+        this.continue(this._steps[this.selected]);
+      }
+
+      /** @protected */
+      continue (step) {
+        if (this.linear && step.error) return;
+        step.completed = true;
+        this.notifyPath('_steps');
+        this.selected = this._findNextStep(this.selected);
+      }
+
+      /** @protected */
+      back(step) {
+        if (this.selected > 0) {
+          this.selected = this.selected - 1;
+        }
+      }
+
+      /** @protected */
+      skip(step) {
+        this.selected = this._findNextStep(this.selected);
+      }
+
+      /** @protected */
+      cancel(step) {
+
+      }
 
       /**
-       * @namespace UrDeveloper
+       * Reset the stepper and all its steps to the initial state.
        */
-      window.UrDeveloper = window.UrDeveloper || {};
-      UrDeveloper.UdStepperElement = UdStepperElement;
+      reset() {
+        this.selected = 0;
+        this._steps.forEach(s => s._reset());
+        this.notifyPath('_steps');
+      }
+
+      /**
+       * Toggle the orientation between horizontal and vertical
+       */
+      toggleOrientation() {
+        this.vertical = !this.vertical;
+      }
+
+      _handleStepActivate(evt) {
+        /*
+         * the logic here:
+         * User is allowed to select any step if stepper is not linear
+         * If stepper is linear: 
+         *  - allow user to revisit a completed editable step
+         *  - allow user to revist an optional step as long as is not completed
+         */
+        if (this.linear) {
+          const step = this._steps[evt.detail.selected];
+          if (!step) return;
+          if ((step.completed && step.editable) || (!step.completed && step.optional)) {
+            return;
+          }
+          evt.preventDefault();
+        }
+      }
+
+      _setSlotNames(steps, vertical) {
+        if (!this._steps) return;
+        steps.forEach((step, i) => {
+          step.setAttribute('slot', this.vertical ? 'slot' + i : 'horizontal');
+        });
+      }
+
+      _selectionChanged(selected) {
+
+        this._steps.forEach((step, i) => {
+          step.selected = i == selected;
+        });
+      }
+
+      _isCompleted(steps) {
+        if (!steps || steps.length === 0) return false;
+        //stepper is completed when all non-optional steps are completed.
+        return steps.filter(s => s.completed || s.optional).length == steps.length;
+      }
     }
+
+    window.customElements.define(UdStepperElement.is, UdStepperElement);
+
+    /**
+     * @namespace UrDeveloper
+     */
+    window.UrDeveloper = window.UrDeveloper || {};
+    UrDeveloper.UdStepperElement = UdStepperElement;
+  }
   </script>
 </dom-module>


### PR DESCRIPTION
- Allows elements firing a `step-action` customEvent to be taken properly processed.
```
            app.next = e =>{
               e.target.dispatchEvent(new CustomEvent('step-action', {detail: 'next', bubbles: true, composed: true})); 
            }; 
```
- fix bug of `:host[hide-action]` -> `:host([hide-action])`

