### PR TITLE
preventDefault prevented Events of children

### DIFF
--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -602,7 +602,10 @@
           if ((step.completed && step.editable) || (!step.completed && step.optional) || step.alwaysSelectable) {
             return;
           }
-          evt.preventDefault();
+          // Only call preventDefault() if the event comes from our own iron-selector
+          if (evt.target.id === "selector" && evt.target.selectable === ".header.selectable") {
+            evt.preventDefault();
+          }
         }
       }
 


### PR DESCRIPTION
ud-stepper always calls preventDefault on `iron-activate`-Events. This causes a problem when a iron-selector is used inside of a ud-step. We had the problem of a paper-dropdown not being able to get any selection after index 1.
The above code adds a check to see if the iron-activate event actually originates from the ud-stepper itself.