### PR TITLE
Fix event path

### DIFF
--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -445,7 +445,14 @@
           selectedAttribute: {
             type: String,
             value: 'active'
-          }
+          },
+
+          // @override prevent listen to arrow binding
+          // keyEventTarget: {
+          //   type: Object,
+          //   value: null
+          // }
+
         };
       }
 
@@ -662,7 +669,7 @@
         if (step && index > -1) {
           e.stopPropagation();
           // e.preventDefault();
-          console.info('handle', step, step.disabled);
+          // console.info('handle', step, step.disabled);
           if (this.linear) {
             // if ((step.completed && step.editable) || (!step.completed && step.optional) || step.alwaysSelectable) {
             if (!step.disabled) {

--- a/ud-stepper.html
+++ b/ud-stepper.html
@@ -562,7 +562,8 @@
 
       _handleStepAction(evt) {
         const actionHandler = this[evt.detail.toLowerCase()];
-        const step = evt.path.find(node => this._isStep(node));
+        const path = evt.path || evt.composedPath();
+        const step = path.find(node => this._isStep(node));
         if (actionHandler && step) actionHandler.apply(this, [step]);
       }
 


### PR DESCRIPTION
When getting path of an event, `event.path` is not supported cross-browser. We should be using `event.getComposedPath` instead: 
https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath

Fix #14 